### PR TITLE
Resolve miners being destroyed on custom nodes

### DIFF
--- a/Source/ResourceNodeRandomizer/Private/ResourceNodeRandomizer.cpp
+++ b/Source/ResourceNodeRandomizer/Private/ResourceNodeRandomizer.cpp
@@ -1,7 +1,8 @@
+#include "ResourceNodeRandomizer.h"
+
 #include "Misc/Paths.h"
 #include "HAL/FileManager.h"
 
-#include "ResourceNodeRandomizer.h"
 #include "EngineUtils.h"
 
 #define LOCTEXT_NAMESPACE "FResourceNodeRandomizerModule"

--- a/Source/ResourceNodeRandomizer/Private/SolidResourceNodeSpawner.cpp
+++ b/Source/ResourceNodeRandomizer/Private/SolidResourceNodeSpawner.cpp
@@ -400,10 +400,12 @@ void USolidResourceNodeSpawner::ReplaceStandardResourceNodesUpdate(UWorld* World
             ClosestNode.Key->SetIsOccupied(true);
             ResourceExtractor->mExtractableResource = ClosestNode.Key;
         }
-        else
-        {
-            ResourceExtractor->Destroy();
-        }
+        // I'm not sure what functionality this may break, but it appears that custom nodes
+        // Are handled gracefully already by the engine, and so this may be un-necessary
+//        else
+//        {
+//            ResourceExtractor->Destroy();
+//        }
     }
 
     for (TActorIterator<AFGPortableMiner> It(World); It; ++It)
@@ -419,10 +421,12 @@ void USolidResourceNodeSpawner::ReplaceStandardResourceNodesUpdate(UWorld* World
         {
             PortableMiner->mExtractResourceNode = ClosestNode.Key;
         }
-        else
-        {
-            PortableMiner->Destroy();
-        }
+        // I'm not sure what functionality this may break, but it appears that custom nodes
+        // Are handled gracefully already by the engine, and so this may be un-necessary
+//        else
+//        {
+//            PortableMiner->Destroy();
+//        }
     }
 }
 

--- a/Source/ResourceNodeRandomizer/Private/SolidResourceNodeSpawner.cpp
+++ b/Source/ResourceNodeRandomizer/Private/SolidResourceNodeSpawner.cpp
@@ -1,10 +1,10 @@
+#include "SolidResourceNodeSpawner.h"
+
 #include "Engine/World.h"
 #include "GameFramework/Actor.h"
 #include "Components/BoxComponent.h"
 #include "Engine/StaticMeshActor.h"
 #include "Components/StaticMeshComponent.h"
-
-#include "SolidResourceNodeSpawner.h"
 
 #include "FGResourceNode.h"
 #include "FGResourceNodeBase.h"


### PR DESCRIPTION
First commit is just to resolve UE complaints on compiling, 2nd is to alter the logic so ResourceExtractors are not destroyed. This may have unintended consequences as I am unfamiliar with the codebase.

Originally I was adding checks and trying to add custom resources to a list to be included, but it appears that either Ficsit Farming  or the base game already implements its own system which allows us to just ignore these miners instead of destroying them when they're not in the list of nodes your mod maintains.